### PR TITLE
fix(build): use valid organisation name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
 ThisBuild / tlBaseVersion := "0.1"
 
-ThisBuild / organization     := "mostly "
+ThisBuild / organization     := "mostly"
 ThisBuild / organizationName := "Mostly Codes"
 ThisBuild / startYear        := Some(2025)
 ThisBuild / licenses         := Seq(License.MIT)


### PR DESCRIPTION
Organisation names with spaces cause issues with generated URLs in the javadoc build.

```
❯ sbt 
copying runtime jar...
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by net.openhft.hashing.UnsafeAccess (file:/Users/adamking/.sbt/boot/scala-2.12.20/org.scala-sbt/sbt/1.11.5/zero-allocation-hashing-0.16.jar)
WARNING: Please consider reporting this to the maintainers of class net.openhft.hashing.UnsafeAccess
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.scalasbt.ipcsocket.NativeLoader in an unnamed module (file:/Users/adamking/.sbt/boot/scala-2.12.20/org.scala-sbt/sbt/1.11.5/ipcsocket-1.6.3.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

[info] welcome to sbt 1.11.5 (Eclipse Adoptium Java 24)
[info] loading settings for project uncertain-tee-build from plugins.sbt...
[info] loading project definition from /Users/adamking/Development/uncertain-tee/project
[info] loading settings for project root from build.sbt...
[info] set scmInfo to https://github.com/MostlyScala/uncertain-tee
java.net.URISyntaxException: Illegal character in path at index 34: https://javadoc.invalid/doc/mostly /uncertain-tee_3/0.1-2bea232-SNAPSHOT/
        at java.base/java.net.URI$Parser.fail(URI.java:2995)
        at java.base/java.net.URI$Parser.checkChars(URI.java:3166)
        at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3248)
        at java.base/java.net.URI$Parser.parse(URI.java:3196)
        at java.base/java.net.URI.<init>(URI.java:645)
        at sbt.package$.url(package.scala:35)
        at org.typelevel.sbt.TypelevelSonatypePlugin$.$anonfun$hostedApiUrl$2(TypelevelSonatypePlugin.scala:76)
        at scala.Option.map(Option.scala:230)
        at org.typelevel.sbt.TypelevelSonatypePlugin$.$anonfun$hostedApiUrl$1(TypelevelSonatypePlugin.scala:74)
        at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:229)
        at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:171)
        at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:88)
        at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:100)
        at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:95)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
        at java.base/java.lang.Thread.run(Thread.java:1447)
[error] java.net.URISyntaxException: Illegal character in path at index 34: https://javadoc.invalid/doc/mostly /uncertain-tee_3/0.1-2bea232-SNAPSHOT/
```