### PR TITLE
ComputationTree Map and Pure to avoid UUID instantiation and map access where unnecessary

### DIFF
--- a/uncertain-tee-cats/src/main/scala/mostly/uncertaintee/cats/package.scala
+++ b/uncertain-tee-cats/src/main/scala/mostly/uncertaintee/cats/package.scala
@@ -32,6 +32,7 @@ package object cats {
 
   /** @see [[mostly.uncertaintee.styledocs.WhyIsThisImplicitAndNotGiven]] */
   implicit val uncertainMonad: StackSafeMonad[Uncertain] = new StackSafeMonad[Uncertain] {
+    override def map[A, B](fa: Uncertain[A])(f: A => B): Uncertain[B]                = fa.map(f)
     override def flatMap[A, B](fa: Uncertain[A])(f: A => Uncertain[B]): Uncertain[B] = fa.flatMap(f)
     override def pure[A](x: A): Uncertain[A]                                         = Uncertain.always(x)
   }

--- a/uncertain-tee-scalacheck/src/main/scala/mostly/uncertaintee/scalacheck/UncertainInstances.scala
+++ b/uncertain-tee-scalacheck/src/main/scala/mostly/uncertaintee/scalacheck/UncertainInstances.scala
@@ -118,6 +118,4 @@ trait UncertainInstances {
     triangularUncertain()
   )
 
-
-
 }

--- a/uncertain-tee/src/main/scala/mostly/uncertaintee/ops/ChanceOps.scala
+++ b/uncertain-tee/src/main/scala/mostly/uncertaintee/ops/ChanceOps.scala
@@ -375,7 +375,7 @@ trait ChanceOps {
     def promille(p: Double)(using random: Random = new Random()): Uncertain[Boolean] = permille(p)(using random)
 
     // 0-9%
-    def percent0(using random: Random = new Random()): Uncertain[Boolean]  = Uncertain.always(false)
+    def percent0: Uncertain[Boolean]                                       = Uncertain.always(false)
     def percent1(using random: Random = new Random()): Uncertain[Boolean]  = Uncertain.bernoulli(0.01)(using random)
     def percent2(using random: Random = new Random()): Uncertain[Boolean]  = Uncertain.bernoulli(0.02)(using random)
     def percent3(using random: Random = new Random()): Uncertain[Boolean]  = Uncertain.bernoulli(0.03)(using random)
@@ -484,5 +484,6 @@ trait ChanceOps {
     def percent97(using random: Random = new Random()): Uncertain[Boolean] = Uncertain.bernoulli(0.97)(using random)
     def percent98(using random: Random = new Random()): Uncertain[Boolean] = Uncertain.bernoulli(0.98)(using random)
     def percent99(using random: Random = new Random()): Uncertain[Boolean] = Uncertain.bernoulli(0.99)(using random)
+    def percent100: Uncertain[Boolean]                                     = Uncertain.always(true)
   }
 }

--- a/uncertain-tee/src/main/scala/mostly/uncertaintee/ops/ComparisonOps.scala
+++ b/uncertain-tee/src/main/scala/mostly/uncertaintee/ops/ComparisonOps.scala
@@ -178,7 +178,7 @@ trait ComparisonOps {
     *
     * Accuraccy is better if a and b have similar quantile count.
     */
-  implicit private def quantileApproxEqDiscrete[T](using ApproxEq[T], NotGiven[Numeric[T]]): ApproxEq[Quantiles[T]] =
+  implicit def quantileApproxEqDiscrete[T](using ApproxEq[T], NotGiven[Numeric[T]]): ApproxEq[Quantiles[T]] =
     (a, b) => {
       val steps = math.max(a.quantileIntervals, b.quantileIntervals)
 
@@ -197,7 +197,7 @@ trait ComparisonOps {
     }
 
   /** Provides high-accuracy approximate equality for numeric Quantiles. Uses linear interpolation by converting T values to Double. */
-  implicit private def quantileApproxEqInstanceNumeric[T](using num: Numeric[T]): ApproxEq[Quantiles[T]] =
+  implicit def quantileApproxEqInstanceNumeric[T](using num: Numeric[T]): ApproxEq[Quantiles[T]] =
     (a, b) => {
       val steps = math.max(a.quantileIntervals, b.quantileIntervals)
 

--- a/uncertain-tee/src/main/scala/mostly/uncertaintee/ops/FunctionalProgrammingOps.scala
+++ b/uncertain-tee/src/main/scala/mostly/uncertaintee/ops/FunctionalProgrammingOps.scala
@@ -19,8 +19,6 @@ package mostly.uncertaintee.ops
 import mostly.uncertaintee.Uncertain
 import mostly.uncertaintee.syntax.*
 
-import scala.util.Random
-
 /** {{{
   * import mostly.uncertaintee.syntax.functional.*
   * // or just import all the syntax (recommended)
@@ -73,9 +71,9 @@ trait FunctionalProgrammingOps {
       * @return
       *   A single `Uncertain` that, when sampled, produces a list of samples — one from each of the input `Uncertain` instances, preserving all correlations between them.
       */
-    def sequence[T](uncertainTs: Iterable[Uncertain[T]])(using random: Random = new Random()): Uncertain[List[T]] =
+    def sequence[T](uncertainTs: Iterable[Uncertain[T]]): Uncertain[List[T]] =
       uncertainTs.foldRight {
-        Uncertain.always(List.empty[T])(using random)
+        Uncertain.always(List.empty[T])
       }(_ :: _)
 
     /** Applies a function to each element in a collection, where the function returns an `Uncertain` value, then sequences the results into a single `Uncertain` collection.
@@ -117,9 +115,9 @@ trait FunctionalProgrammingOps {
       */
     def traverse[A, T](
       items: Iterable[A]
-    )(f: A => Uncertain[T])(using random: Random = new Random()): Uncertain[List[T]] =
+    )(f: A => Uncertain[T]): Uncertain[List[T]] =
       items.foldRight {
-        Uncertain.always(List.empty[T])(using random)
+        Uncertain.always(List.empty[T])
       } { (elem, acc) =>
         for {
           h <- f(elem)

--- a/uncertain-tee/src/main/scala/mostly/uncertaintee/quantiles/Quartiles.scala
+++ b/uncertain-tee/src/main/scala/mostly/uncertaintee/quantiles/Quartiles.scala
@@ -48,12 +48,12 @@ final case class Quartiles[T](
   def median: T = q2
 
   /** Returns the value at the given Quartile boundary.
-   *
-   * @param n
-   * percentile boundary index (0 to 5)
-   * @return
-   * the value at the specified percentile boundary
-   */
+    *
+    * @param n
+    *   percentile boundary index (0 to 5)
+    * @return
+    *   the value at the specified percentile boundary
+    */
   override def apply(n: Int): T = n match {
     case 0         => q0
     case 1         => q1

--- a/uncertain-tee/src/main/scala/mostly/uncertaintee/quantiles/Quintiles.scala
+++ b/uncertain-tee/src/main/scala/mostly/uncertaintee/quantiles/Quintiles.scala
@@ -43,12 +43,12 @@ final case class Quintiles[T](
   override val quantileIntervals = 5
 
   /** Returns the value at the given Quintile boundary.
-   *
-   * @param n
-   * percentile boundary index (0 to 5)
-   * @return
-   * the value at the specified percentile boundary
-   */
+    *
+    * @param n
+    *   percentile boundary index (0 to 5)
+    * @return
+    *   the value at the specified percentile boundary
+    */
   override def apply(n: Int): T = n match {
     case 0         => q0
     case 1         => q1


### PR DESCRIPTION
* ComputationTree now has a node for Mappings and Pure to avoid extra object allocations for pure values and for chained maps.

https://github.com/MostlyScala/uncertain-tee/issues/55
https://github.com/MostlyScala/uncertain-tee/issues/54

It's elegant to define map via flatmap but in this case we can save quite a few object allocations and lookups