### PR TITLE
SVGs for Uncertain-tee [T] logo

### DIFF
--- a/img/uncertain-tee-logo-sharp.svg
+++ b/img/uncertain-tee-logo-sharp.svg
@@ -1,14 +1,7 @@
-<svg width="428" height="344" viewBox="0 0 428 344" xmlns="http://www.w3.org/2000/svg">
-    <path d="M323 44H236V245H192V44H104V0H323V44Z" fill="#CE3220"/>
-    <path d="M428 0L428 344L384 344L384 0" fill="#0B3540"/>
-    <rect x="341" width="59" height="44" fill="#0B3540"/>
-    <rect x="370" y="300" width="30" height="44" fill="#0B3540"/>
-    <path d="M0 0L0 344L44 344L44 0Z" fill="#0B3540"/>
-    <rect width="59" height="44" transform="matrix(-1 0 0 1 87 0)" fill="#0B3540"/>
-    <rect width="30" height="44" transform="matrix(-1 0 0 1 58 300)" fill="#0B3540"/>
-    <rect x="355" y="220" width="124" height="44" transform="rotate(90 355 220)" fill="#5C7A81"/>
-    <rect x="237" y="260" width="84" height="44" transform="rotate(90 237 260)" fill="#5C7A81"/>
-    <rect x="119" y="220" width="124" height="44" transform="rotate(90 119 220)" fill="#5C7A81"/>
-    <rect x="178" y="141" width="203" height="44" transform="rotate(90 178 141)" fill="#5C7A81"/>
-    <rect x="296" y="141" width="203" height="44" transform="rotate(90 296 141)" fill="#5C7A81"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="428" height="344">
+    <path fill="#ce3220" d="M323 44h-87v201h-44V44h-88V0h219z"/>
+    <path fill="#0b3540" d="M428 0v344h-44V0"/>
+    <path fill="#0b3540" d="M341 0h59v44h-59zm29 300h30v44h-30zM0 0v344h44V0Z"/>
+    <path fill="#0b3540" d="M87 0H28v44h59zM58 300H28v44h30z"/>
+    <path fill="#5c7a81" d="M355 220v124h-44V220zm-118 40v84h-44v-84zm-118-40v124H75V220zm59-79v203h-44V141zm118 0v203h-44V141z"/>
 </svg>

--- a/img/uncertain-tee-logo-soft.svg
+++ b/img/uncertain-tee-logo-soft.svg
@@ -1,16 +1,7 @@
-<svg width="428" height="344" viewBox="0 0 428 344" xmlns="http://www.w3.org/2000/svg">
-    <path d="M323 44H236V245H192V44H104V0H323V44Z" fill="#CE3220"/>
-    <path d="M408 -8.74227e-07C419.046 -3.91405e-07 428 8.9543 428 20L428 324C428 335.046 419.046 344 408 344L384 344L384 -1.9233e-06L408 -8.74227e-07Z"
-          fill="#0B3540"/>
-    <rect x="341" width="59" height="44" fill="#0B3540"/>
-    <rect x="370" y="300" width="30" height="44" fill="#0B3540"/>
-    <path d="M20 -8.74227e-07C8.9543 -3.91405e-07 3.91405e-07 8.9543 8.74228e-07 20L1.41625e-05 324C1.46453e-05 335.046 8.95432 344 20 344L44 344L44 -1.9233e-06L20 -8.74227e-07Z"
-          fill="#0B3540"/>
-    <rect width="59" height="44" transform="matrix(-1 0 0 1 87 0)" fill="#0B3540"/>
-    <rect width="30" height="44" transform="matrix(-1 0 0 1 58 300)" fill="#0B3540"/>
-    <rect x="355" y="220" width="124" height="44" transform="rotate(90 355 220)" fill="#5C7A81"/>
-    <rect x="237" y="260" width="84" height="44" transform="rotate(90 237 260)" fill="#5C7A81"/>
-    <rect x="119" y="220" width="124" height="44" transform="rotate(90 119 220)" fill="#5C7A81"/>
-    <rect x="178" y="141" width="203" height="44" transform="rotate(90 178 141)" fill="#5C7A81"/>
-    <rect x="296" y="141" width="203" height="44" transform="rotate(90 296 141)" fill="#5C7A81"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="428" height="344">
+    <path fill="#ce3220" d="M323 44h-87v201h-44V44h-88V0h219z"/>
+    <path fill="#0b3540" d="M408 0c11.046 0 20 8.954 20 20v304c0 11.046-8.954 20-20 20h-24V0z"/>
+    <path fill="#0b3540" d="M341 0h59v44h-59zm29 300h30v44h-30zM20 0C8.954 0 0 8.954 0 20v304c0 11.046 8.954 20 20 20h24V0z"/>
+    <path fill="#0b3540" d="M87 0H28v44h59zM58 300H28v44h30z"/>
+    <path fill="#5c7a81" d="M355 220v124h-44V220zm-118 40v84h-44v-84zm-118-40v124H75V220zm59-79v203h-44V141zm118 0v203h-44V141z"/>
 </svg>


### PR DESCRIPTION
Big thanks to Leah Grant (https://www.linkedin.com/in/leah-grant82/) for vectorising the design, and to @AdamJKing for feedback on the initial logo concept. 

Quite happy with this in the end - very simple, very literal, decently evocative. For posterity, this is keeping to the "standard" set of Scala library colours, and is a bracketed T rising out of a histogram, which, as @AdamJKing put it, is about as literal a logo as it's possible to have for this library... in which typed results rise out of uncertain distributions naturally.

Two variants, a soft and a sharp. I consider the the sharp version the default one, but I could see situations where I might prefer a softer version; committing both.

Will update README.md etc with this 'branding' in a separate PR!